### PR TITLE
don't default into the random model

### DIFF
--- a/compsoc/voter_model.py
+++ b/compsoc/voter_model.py
@@ -114,5 +114,5 @@ def get_pairs_from_model(num_candidates: int, num_voters: int, voters_model: str
     elif voters_model == 'random':
         pairs = generate_random_votes(num_voters, num_candidates)
     else:
-        pairs = generate_random_votes(num_voters, num_candidates)
+        raise ValueError(f'Unknown model: {voters_model}')
     return pairs


### PR DESCRIPTION
I don't think it's a good idea to default into the random model since if you misspell the model name, you might think you are getting a "gaussian" model, for example, but the ballots are random.