### PR TITLE
Fixing the args.distort_rate typo in the run.py file

### DIFF
--- a/run.py
+++ b/run.py
@@ -53,7 +53,7 @@ def main():
     plot_comparison_results(args.voters_model, results, args.num_voters, args.num_candidates,
                             args.num_topn, args.num_iterations, distortion_ratio=0.0, save_figure=True)
     
-    if args.distort_rate == 0.0:
+    if args.distortion_ratio == 0.0:
         return
 
     results2 = {}
@@ -62,7 +62,7 @@ def main():
                                            args.num_voters,
                                            args.num_topn,
                                            args.voters_model,
-                                           distortion_ratio=args.distort_rate,
+                                           distortion_ratio=args.distortion_ratio,
                                            verbose=True)
     plot_comparison_results(args.voters_model, results2, args.num_voters, args.num_candidates,
                             args.num_topn, args.num_iterations, distortion_ratio=args.distortion_ratio, save_figure=True)


### PR DESCRIPTION
Hi, I realized that there is a typo on **lines 56 and 65** of the **"run.py" file**, where **"args.distortion_ratio"** is typed as **"args.distort_rate"**. This typo causes an error during local testing. I am proposing to fix by changing all to **"args.distortion_ratio"**. This pull request is consistent with the usage in **"tests/test1/run.py" file** as well. Kind regards. 