### PR TITLE
Fixed issue in __calc_paths and added __calc_path_preference() to the init

### DIFF
--- a/compsoc/profile.py
+++ b/compsoc/profile.py
@@ -60,6 +60,7 @@ class Profile:
         self.__calc_votes_per_candidate()
         # Initialize a Path Preference Graph
         self.path_preference_graph = {candidate: {} for candidate in self.candidates}
+        self.__calc_path_preference()
 
     # ---------------------------------------------
     # Comparison routines
@@ -289,7 +290,6 @@ class Profile:
             # End of path
             if candidate == candidate2:
                 paths.append(path)  # add to possible paths
-                path = []  # start a new path
             else:  # path isn't over
                 new_candidates = candidates - {candidate}
                 subpath = self.__calc_paths(candidate, candidate2,
@@ -298,6 +298,7 @@ class Profile:
                 # concatenate with current path and save it
                 for weights in subpath:
                     paths.append(path + weights)
+            path = []  # start a new path
         # Return a list of possible paths between candidate1 and candidate2
         return paths
 


### PR DESCRIPTION
My proposed changes are twofold:

(1) One line we have path = []  # start a new path, meaning the end of a path is reached and the list is reset. However this only gets implemented if the if statement on 291 is true. If this if statmenent is false, the recursive call gives us subpaths, and all the current path+subpaths are added. However, path = [] is never called, even though the for loop in line 287 is about to start a new iteration (to calculate paths through a new candidate). This results in incorrect paths (I have checked). Moving path = [] outside the if statement makes sure that the path is reset before every iteration of the for loop.

(2) __calc_path_preference function is defined but never ran in profile.py. Since this is a static function, it cannot be called from an instance of Profile. This results in profile. path_preference_graph to always be an empty list. We could just copy and paste the same method to our rule, but this would cause a lot of time (and would be repeated every time the method is called). It is much more efficient if this method is called upon initialization, as (I believe) originally intended.